### PR TITLE
Remove uneeded and vulnerable package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "license": "MIT",
     "require": {
         "php": ">=5.3.0",
-        "firebase/php-jwt": "^1.0.0",
         "fanout/pubcontrol": "^2.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
firebase/php-jwt doesn't look like it's required by this package. Removing it will stop dependency conflicts with other packages (such as google/auth)

Additionally, Sensiolabs reports that firebase/php-jwt versions <2.0.0 has a vulnerability (https://security.sensiolabs.org/database?package=firebase/php-jwt)
